### PR TITLE
Operator overload

### DIFF
--- a/class.lua
+++ b/class.lua
@@ -87,6 +87,24 @@ function Class:set(prop, value)
 	end
 end
 
+---perform operator overloading for an new object of a class
+---@param class table
+---@param obj table
+local function opOverload(class, obj)
+	local opKeys = {
+		"__mode", "__tostring", "__len", "__pairs", "__ipairs", "__gc", "__name", "__close", --Special Operators
+		"__unm", "__add", '__sub', "__mul", "__div", "__idiv", "__mod", "__pow", "__concat", --Mathematic Operators
+		"__eq", "__lt", "__le",                                                        --Equivalence Comparison Operators
+		"__band", "__bor", "__bxor", "__bnot", "__shl", "__shr"                        --Bitwise Operators
+	}
+	local objMt = getmetatable(obj)
+	for _, operator in pairs(opKeys) do
+		if class[operator] then
+			objMt[operator] = class[operator]
+		end
+	end
+end
+
 -- create an instance of an object with constructor parameters
 function Class:new(...)
 	local obj = self:extend({})

--- a/class.lua
+++ b/class.lua
@@ -109,6 +109,10 @@ end
 function Class:new(...)
 	local obj = self:extend({})
 	if obj.init then obj:init(...) end
+
+	-- overload operators
+	opOverload(self, obj)
+
 	return obj
 end
 


### PR DESCRIPTION
This pull request aims to add operator-overloading to the classes created by the original library

The usage example of the added feature is as follows:

```Lua
    require "class"

    Vector2 = Class:extend()
    function Vector2:init(x, y)
        self.x = x
        self.y = y
    end

    -- attributes --
    Vector2:set{x = 0, y = 0}

    -- operator overloading --
    function Vector2:__add(other)
        return Vector2(
            self.x + other.x,
            self.y + other.y
        )
    end

    function Vector2:__tostring()
        return string.format("Vector2(%f, %f)", self.x, self.y)
    end

    -----------------------------------------------------------
    local vec1 = Vector2(1, 2)
    local vec2 = Vector2(3, 4)
    print(vec1 + vec2)
```

The output of the example above is:

```
    "Vector2(4.0, 6.0)"
```
